### PR TITLE
Fix server crash on hex parse fail

### DIFF
--- a/util/tx-data.js
+++ b/util/tx-data.js
@@ -43,6 +43,10 @@ function string2Hex(str) {
 function parseMemoData(txMemos) {
   const memoData = txMemos[0].Memo.MemoData;
 
+  if (!memoData) {
+    return '';
+  }
+
   const parsedMemo = hex2String(memoData);
 
   return parsedMemo;


### PR DESCRIPTION
Fix server crash on hex parse fail
- only attempt parse MemoData if exists
- return '' if none